### PR TITLE
Fix typedef in farming_water_management template

### DIFF
--- a/simulation/data/technologies/zapotecs/farming_water_management.json
+++ b/simulation/data/technologies/zapotecs/farming_water_management.json
@@ -12,8 +12,8 @@
 	"researchTime": 20,
 	"tooltip": "Corn Fields and Farmsteads +200% health, Slaves +25% grain gathering rate.",
 	"modifications": [
-		{"value": "Health/Max", "multiply": 3, "affects": ["Field"]},
-		{"value": "ResourceGatherer/Rates/food.grain", "multiply": 1.25, "affects": ["Slave"]}
+		{"value": "Health/Max", "multiply": 3, "affects": "Field"},
+		{"value": "ResourceGatherer/Rates/food.grain", "multiply": 1.25, "affects": "Slave"}
 	],
 	"soundComplete": "interface/alarm/alarm_upgradearmory.xml"
 }


### PR DESCRIPTION
In middlegame generated error:
ERROR: Error in timer on entity 7468, IID80, function ProgressTimeout: TypeError: mod.affects.split is not a function
  DeriveModificationsFromTech@globalscripts/ModificationTemplates.js:70:34
  TechnologyManager.prototype.ResearchTechnology@simulation/components/TechnologyManager.js:228:52
  ProductionQueue.prototype.ProgressTimeout@simulation/components/ProductionQueue.js:874:26
  Timer.prototype.OnUpdate@simulation/components/Timer.js:139:44
  
![scale](https://user-images.githubusercontent.com/3074285/131182335-415d3ba5-68bb-44c1-aee3-6b8822ba59ed.png)

Problem in type definition "affect", should be plain string. Example in maingame https://github.com/0ad/0ad/blob/master/binaries/data/mods/public/simulation/data/technologies/civbonuses/gaul_cavalry.json

Patch fix this warnings