### PR TITLE
README screenshots now link to screenshots hosted within this repo

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -14,13 +14,13 @@ alt="0 A.D. Delenda Est -- Isometric View with the ATHENIANS" width="750" height
 
 ### Gameplay screenshot of Suebian Germans
 
-![Delenda Est](https://github.com/psypherium/delenda_est/blob/patch-1/.github/delenda_est_screenshot.jpg "Delenda Est")
+![Delenda Est](https://github.com/JustusAvramenko/delenda_est/blob/master/.github/delenda_est_screenshot.jpg "Delenda Est")
 
 ---
 
 ### Gameplay screenshot of Zapotecs
 
-![Delenda Est](https://github.com/psypherium/delenda_est/blob/master/.github/a25_zapotecs(v2).jpg "Delenda Est")
+![Delenda Est](https://github.com/JustusAvramenko/delenda_est/blob/master/.github/a25_zapotecs(v2).jpg "Delenda Est")
 
 ---
 


### PR DESCRIPTION
README screenshots now link to screenshots hosted within this repo, previously the README was trying to load images from the fork I used to create the previous pull request, but the fork no longer existed which broke the links. This patch means that will no longer happen in the future.