### PR TITLE
Add match settings scripts and summary UI components

### DIFF
--- a/gui/session/session.xml
+++ b/gui/session/session.xml
@@ -13,6 +13,7 @@
 <script directory="gui/session/diplomacy/playercontrols/"/>
 <script directory="gui/session/lobby/"/>
 <script directory="gui/session/lobby/LobbyRatingReport/"/>
+<script directory="gui/session/match_settings/"/>
 <script directory="gui/session/message_box/"/>
 <script directory="gui/session/minimap/"/>
 <script directory="gui/session/objectives/"/>
@@ -54,6 +55,7 @@
 	<include directory="gui/session/chat/"/>
 	<include directory="gui/session/developer_overlay/"/>
 	<include directory="gui/session/dialogs/"/>
+	<include directory="gui/session/match_settings/"/>
 	<include directory="gui/session/diplomacy/"/>
 	<include directory="gui/session/objectives/"/>
 	<include file="gui/session/GameSpeedControl.xml"/>

--- a/gui/summary/summary.js
+++ b/gui/summary/summary.js
@@ -1,0 +1,608 @@
+const g_CivData = loadCivData(false, false);
+
+var g_ScorePanelsData;
+
+var g_MaxHeadingTitle = 20;
+var g_LongHeadingWidth = 250;
+var g_PlayerBoxYSize = 40;
+var g_PlayerBoxGap = 2;
+var g_PlayerBoxAlpha = 50;
+var g_TeamsBoxYStart = 40;
+
+var g_TypeColors = {
+	"blue": "196 198 255",
+	"green": "201 255 200",
+	"red": "255 213 213",
+	"yellow": "255 255 157"
+};
+
+/**
+ * Colors, captions and format used for units, structures, etc. types
+ */
+var g_SummaryTypes = {
+	"percent": {
+		"color": "",
+		"caption": "%",
+		"postfix": "%"
+	},
+	"trained": {
+		"color": g_TypeColors.green,
+		"caption": translate("Trained"),
+		"postfix": " / "
+	},
+	"constructed": {
+		"color": g_TypeColors.green,
+		"caption": translate("Constructed"),
+		"postfix": " / "
+	},
+	"gathered": {
+		"color": g_TypeColors.green,
+		"caption": translate("Gathered"),
+		"postfix": " / "
+	},
+	"count": {
+		"caption": translate("Count"),
+		"hideInSummary": true
+	},
+	"sent": {
+		"color": g_TypeColors.green,
+		"caption": translate("Sent"),
+		"postfix": " / "
+	},
+	"bought": {
+		"color": g_TypeColors.green,
+		"caption": translate("Bought"),
+		"postfix": " / "
+	},
+	"income": {
+		"color": g_TypeColors.green,
+		"caption": translate("Income"),
+		"postfix": " / "
+	},
+	"captured": {
+		"color": g_TypeColors.yellow,
+		"caption": translate("Captured"),
+		"postfix": " / "
+	},
+	"succeeded": {
+		"color": g_TypeColors.green,
+		"caption": translate("Succeeded"),
+		"postfix": " / "
+	},
+	"destroyed": {
+		"color": g_TypeColors.blue,
+		"caption": translate("Destroyed"),
+		"postfix": "\n"
+	},
+	"killed": {
+		"color": g_TypeColors.blue,
+		"caption": translate("Killed"),
+		"postfix": "\n"
+	},
+	"lost": {
+		"color": g_TypeColors.red,
+		"caption": translate("Lost"),
+		"postfix": ""
+	},
+	"used": {
+		"color": g_TypeColors.red,
+		"caption": translate("Used"),
+		"postfix": ""
+	},
+	"received": {
+		"color": g_TypeColors.red,
+		"caption": translate("Received"),
+		"postfix": ""
+	},
+	"population": {
+		"color": g_TypeColors.red,
+		"caption": translate("Population"),
+		"postfix": ""
+	},
+	"sold": {
+		"color": g_TypeColors.red,
+		"caption": translate("Sold"),
+		"postfix": ""
+	},
+	"outcome": {
+		"color": g_TypeColors.red,
+		"caption": translate("Outcome"),
+		"postfix": ""
+	},
+	"failed": {
+		"color": g_TypeColors.red,
+		"caption": translate("Failed"),
+		"postfix": ""
+	}
+};
+
+// Translation: Unicode encoded infinity symbol indicating a division by zero in the summary screen.
+var g_InfinitySymbol = translate("\u221E");
+
+var g_Teams = [];
+
+var g_PlayerCount;
+
+var g_GameData;
+var g_ResourceData = new Resources();
+
+/**
+ * Selected chart indexes.
+ */
+var g_SelectedChart = {
+	"category": [0, 0],
+	"value": [0, 1],
+	"type": [0, 0]
+};
+
+async function init(data)
+{
+	initSummaryData(data);
+	initGUISummary();
+
+	while (true)
+	{
+		const branchless = await new Promise(resolve => {
+			Engine.GetGUIObjectByName("continueButton").onPress = resolve.bind(null, true);
+			Engine.GetGUIObjectByName("summaryHotkey").onPress = resolve.bind(null, true);
+			Engine.GetGUIObjectByName("cancelHotkey").onPress = resolve.bind(null, false);
+		});
+
+		if (branchless || data.gui.isInGame)
+			return continueButton(data);
+	}
+}
+
+function initSummaryData(data)
+{
+	g_GameData = data;
+	g_ScorePanelsData = getScorePanelsData();
+
+	let teamCharts = false;
+	if (data && data.gui && data.gui.summarySelection)
+	{
+		g_TabCategorySelected = data.gui.summarySelection.panel;
+		g_SelectedChart = data.gui.summarySelection.charts;
+		teamCharts = data.gui.summarySelection.teamCharts;
+	}
+	Engine.GetGUIObjectByName("toggleTeamBox").checked = g_Teams && teamCharts;
+
+	initTeamData();
+	calculateTeamCounterDataHelper();
+}
+
+function initGUISummary()
+{
+	initGUIWindow();
+	initPlayerBoxPositions();
+	initGUICharts();
+	initGUILabels();
+	initGUIButtons();
+}
+
+/**
+ * Sets the style and title of the page.
+ */
+function initGUIWindow()
+{
+	const summaryWindow = Engine.GetGUIObjectByName("summaryWindow");
+	summaryWindow.sprite = g_GameData.gui.dialog ? "ModernDialog" : "ModernWindow";
+	summaryWindow.size = g_GameData.gui.dialog ? "16 24 100%-16 100%-24" : "0 0 100% 100%";
+	Engine.GetGUIObjectByName("summaryWindowTitle").size = g_GameData.gui.dialog ? "50%-128 -16 50%+128 16" : "50%-128 4 50%+128 36";
+}
+
+function selectPanelGUI(panel)
+{
+	adjustTabDividers(Engine.GetGUIObjectByName("tabButton[" + panel + "]").size);
+
+	const generalPanel = Engine.GetGUIObjectByName("generalPanel");
+	const chartsPanel = Engine.GetGUIObjectByName("chartsPanel");
+
+	// We assume all scorePanels come before the charts.
+	const chartsHidden = panel < g_ScorePanelsData.length;
+	generalPanel.hidden = !chartsHidden;
+	chartsPanel.hidden = chartsHidden;
+	if (chartsHidden)
+		updatePanelData(g_ScorePanelsData[panel]);
+	else
+		[0, 1].forEach(updateCategoryDropdown);
+}
+
+function constructPlayersWithColor(color, playerListing)
+{
+	return sprintf(translateWithContext("Player listing with color indicator",
+		"%(colorIndicator)s %(playerListing)s"),
+	{
+		"colorIndicator": setStringTags(translateWithContext(
+			"Charts player color indicator", "■"), { "color": color }),
+		"playerListing": playerListing
+	});
+}
+
+function updateChartColorAndLegend()
+{
+	const playerColors = [];
+	for (let i = 1; i <= g_PlayerCount; ++i)
+	{
+		const playerState = g_GameData.sim.playerStates[i];
+		playerColors.push(
+			Math.floor(playerState.color.r * 255) + " " +
+			Math.floor(playerState.color.g * 255) + " " +
+			Math.floor(playerState.color.b * 255) + " 255"
+		);
+	}
+
+	for (let i = 0; i < 2; ++i)
+		Engine.GetGUIObjectByName("chart[" + i + "]").series_color =
+			Engine.GetGUIObjectByName("toggleTeamBox").checked ?
+				g_Teams.filter(el => el !== null).map(players => playerColors[players[0] - 1]) :
+				playerColors;
+
+	const chartLegend = Engine.GetGUIObjectByName("chartLegend");
+	chartLegend.caption = (Engine.GetGUIObjectByName("toggleTeamBox").checked ?
+		g_Teams.filter(el => el !== null).map(players =>
+			constructPlayersWithColor(playerColors[players[0] - 1],	players.map(player =>
+				g_GameData.sim.playerStates[player].name
+			).join(translateWithContext("Player listing", ", ")))
+		) :
+		g_GameData.sim.playerStates.slice(1).map((state, index) =>
+			constructPlayersWithColor(playerColors[index], state.name))
+	).join("   ");
+}
+
+function initGUICharts()
+{
+	updateChartColorAndLegend();
+	const chart1Part = Engine.GetGUIObjectByName("chart[1]Part");
+	const chart1PartSize = chart1Part.size;
+	chart1PartSize.rright += 50;
+	chart1PartSize.rleft += 50;
+	chart1PartSize.right -= 5;
+	chart1PartSize.left -= 5;
+	chart1Part.size = chart1PartSize;
+	Engine.GetGUIObjectByName("toggleTeam").hidden = !g_Teams;
+}
+
+function resizeDropdown(dropdown)
+{
+	const size = dropdown.size;
+	size.bottom = dropdown.size.top +
+		(Engine.GetTextWidth(dropdown.font, dropdown.list[dropdown.selected]) >
+			dropdown.size.right - dropdown.size.left - 28 &&
+		    dropdown.list[dropdown.selected].indexOf(" ") !== -1 ? 42 : 28);
+	dropdown.size = size;
+}
+
+function updateCategoryDropdown(number)
+{
+	const chartCategory = Engine.GetGUIObjectByName("chart[" + number + "]CategorySelection");
+	chartCategory.list_data = g_ScorePanelsData.map((panel, idx) => idx);
+	chartCategory.list = g_ScorePanelsData.map(panel => panel.label);
+	chartCategory.onSelectionChange = function() {
+		if (!this.list_data[this.selected])
+			return;
+		if (g_SelectedChart.category[number] != this.selected)
+		{
+			g_SelectedChart.category[number] = this.selected;
+			g_SelectedChart.value[number] = 0;
+			g_SelectedChart.type[number] = 0;
+		}
+
+		resizeDropdown(this);
+		updateValueDropdown(number, this.list_data[this.selected]);
+	};
+	chartCategory.selected = g_SelectedChart.category[number];
+}
+
+function updateValueDropdown(number, category)
+{
+	const chartValue = Engine.GetGUIObjectByName("chart[" + number + "]ValueSelection");
+	const list = g_ScorePanelsData[category].headings.map(heading => heading.caption);
+	list.shift();
+	chartValue.list = list;
+	const list_data = g_ScorePanelsData[category].headings.map(heading => heading.identifier);
+	list_data.shift();
+	chartValue.list_data = list_data;
+	chartValue.onSelectionChange = function() {
+		if (!this.list_data[this.selected])
+			return;
+		if (g_SelectedChart.value[number] != this.selected)
+		{
+			g_SelectedChart.value[number] = this.selected;
+			g_SelectedChart.type[number] = 0;
+		}
+
+		resizeDropdown(this);
+		updateTypeDropdown(number, category, this.list_data[this.selected], this.selected);
+	};
+	chartValue.selected = g_SelectedChart.value[number];
+}
+
+function updateTypeDropdown(number, category, item, itemNumber)
+{
+	const testValue = g_ScorePanelsData[category].counters[itemNumber].fn(g_GameData.sim.playerStates[1], 0, item);
+	const hide = !g_ScorePanelsData[category].counters[itemNumber].fn ||
+		typeof testValue != "object" || Object.keys(testValue).length < 2;
+	Engine.GetGUIObjectByName("chart[" + number + "]TypeLabel").hidden = hide;
+	const chartType = Engine.GetGUIObjectByName("chart[" + number + "]TypeSelection");
+	chartType.hidden = hide;
+	if (hide)
+	{
+		updateChart(number, category, item, itemNumber, Object.keys(testValue)[0] || undefined);
+		return;
+	}
+
+	chartType.list = Object.keys(testValue).map(type => g_SummaryTypes[type].caption);
+	chartType.list_data = Object.keys(testValue);
+	chartType.onSelectionChange = function() {
+		if (!this.list_data[this.selected])
+			return;
+		g_SelectedChart.type[number] = this.selected;
+		resizeDropdown(this);
+		updateChart(number, category, item, itemNumber, this.list_data[this.selected]);
+	};
+	chartType.selected = g_SelectedChart.type[number];
+}
+
+function updateChart(number, category, item, itemNumber, type)
+{
+	if (!g_ScorePanelsData[category].counters[itemNumber].fn)
+		return;
+	const chart = Engine.GetGUIObjectByName("chart[" + number + "]");
+	chart.format_y = g_ScorePanelsData[category].headings[itemNumber + 1].format || "INTEGER";
+	Engine.GetGUIObjectByName("chart[" + number + "]XAxisLabel").caption = translate("Time elapsed");
+
+	const series = [];
+	if (Engine.GetGUIObjectByName("toggleTeamBox").checked)
+		for (const team in g_Teams)
+		{
+			const data = [];
+			for (const index in g_GameData.sim.playerStates[1].sequences.time)
+			{
+				let value = g_ScorePanelsData[category].teamCounterFn(team, index, item,
+					g_ScorePanelsData[category].counters, g_ScorePanelsData[category].headings);
+				if (type)
+					value = value[type];
+				data.push({ "x": g_GameData.sim.playerStates[1].sequences.time[index], "y": value });
+			}
+			series.push(data);
+		}
+	else
+		for (let j = 1; j <= g_PlayerCount; ++j)
+		{
+			const playerState = g_GameData.sim.playerStates[j];
+			const data = [];
+			for (const index in playerState.sequences.time)
+			{
+				let value = g_ScorePanelsData[category].counters[itemNumber].fn(playerState, index, item);
+				if (type)
+					value = value[type];
+				data.push({ "x": playerState.sequences.time[index], "y": value });
+			}
+			series.push(data);
+		}
+
+	chart.series = series;
+}
+
+function adjustTabDividers(tabSize)
+{
+	const tabButtonsLeft = Engine.GetGUIObjectByName("tabButtonsFrame").size.left;
+
+	const leftSpacer = Engine.GetGUIObjectByName("tabDividerLeft");
+	const leftSpacerSize = leftSpacer.size;
+	leftSpacerSize.right = tabSize.left + tabButtonsLeft + 2;
+	leftSpacer.size = leftSpacerSize;
+
+	const rightSpacer = Engine.GetGUIObjectByName("tabDividerRight");
+	const rightSpacerSize = rightSpacer.size;
+	rightSpacerSize.left = tabSize.right + tabButtonsLeft - 2;
+	rightSpacer.size = rightSpacerSize;
+}
+
+function updatePanelData(panelInfo)
+{
+	resetGeneralPanel();
+	updateGeneralPanelHeadings(panelInfo.headings);
+	updateGeneralPanelTitles(panelInfo.titleHeadings);
+	const rowPlayerObjectWidth = updateGeneralPanelCounter(panelInfo.counters);
+	updateGeneralPanelTeams();
+
+	const index = g_GameData.sim.playerStates[1].sequences.time.length - 1;
+	const playerBoxesCounts = [];
+	for (let i = 0; i < g_PlayerCount; ++i)
+	{
+		const playerState = g_GameData.sim.playerStates[i + 1];
+
+		if (!playerBoxesCounts[playerState.team + 1])
+			playerBoxesCounts[playerState.team + 1] = 1;
+		else
+			playerBoxesCounts[playerState.team + 1] += 1;
+
+		const positionObject = playerBoxesCounts[playerState.team + 1] - 1;
+		let rowPlayer = "playerBox[" + positionObject + "]";
+		let playerOutcome = "playerOutcome[" + positionObject + "]";
+		let playerNameColumn = "playerName[" + positionObject + "]";
+		let playerCivicBoxColumn = "civIcon[" + positionObject + "]";
+		let playerCounterValue = "valueData[" + positionObject + "]";
+
+		if (playerState.team != -1)
+		{
+			rowPlayer = "playerBoxt[" + playerState.team + "][" + positionObject + "]";
+			playerOutcome = "playerOutcomet[" + playerState.team + "][" + positionObject + "]";
+			playerNameColumn = "playerNamet[" + playerState.team + "][" + positionObject + "]";
+			playerCivicBoxColumn = "civIcont[" + playerState.team + "][" + positionObject + "]";
+			playerCounterValue = "valueDataTeam[" + playerState.team + "][" + positionObject + "]";
+		}
+
+		const colorString = "color: " +
+			Math.floor(playerState.color.r * 255) + " " +
+			Math.floor(playerState.color.g * 255) + " " +
+			Math.floor(playerState.color.b * 255);
+
+		const rowPlayerObject = Engine.GetGUIObjectByName(rowPlayer);
+		rowPlayerObject.hidden = false;
+		rowPlayerObject.sprite = colorString + " " + g_PlayerBoxAlpha;
+
+		const boxSize = rowPlayerObject.size;
+		boxSize.right = rowPlayerObjectWidth;
+		rowPlayerObject.size = boxSize;
+
+		setOutcomeIcon(playerState.state, Engine.GetGUIObjectByName(playerOutcome));
+
+		playerNameColumn = Engine.GetGUIObjectByName(playerNameColumn);
+		playerNameColumn.caption = g_GameData.sim.playerStates[i + 1].name;
+		playerNameColumn.tooltip = translateAISettings(g_GameData.sim.mapSettings.PlayerData[i + 1]);
+
+		const civIcon = Engine.GetGUIObjectByName(playerCivicBoxColumn);
+		civIcon.sprite = "stretched:" + g_CivData[playerState.civ].Emblem;
+		civIcon.tooltip = g_CivData[playerState.civ].Name;
+
+		updateCountersPlayer(playerState, panelInfo.counters, panelInfo.headings, playerCounterValue, index);
+	}
+
+	const teamCounterFn = panelInfo.teamCounterFn;
+	if (g_Teams && teamCounterFn)
+		updateCountersTeam(teamCounterFn, panelInfo.counters, panelInfo.headings, index);
+}
+
+function continueButton(gameData)
+{
+	const summarySelection = {
+		"panel": g_TabCategorySelected,
+		"charts": g_SelectedChart,
+		"teamCharts": Engine.GetGUIObjectByName("toggleTeamBox").checked
+	};
+	if (gameData.gui.isInGame)
+		return {
+			"summarySelection": summarySelection
+		};
+	if (gameData.gui.dialog)
+		return undefined;
+	else if (Engine.HasXmppClient())
+		Engine.SwitchGuiPage("page_lobby.xml", { "dialog": false });
+	else if (gameData.gui.isReplay)
+		Engine.SwitchGuiPage("page_replaymenu.xml", {
+			"replaySelectionData": gameData.gui.replaySelectionData,
+			"summarySelection": summarySelection
+		});
+	else if (gameData.campaignData)
+		Engine.SwitchGuiPage(gameData.nextPage, gameData.campaignData);
+	else
+		Engine.SwitchGuiPage("page_pregame.xml");
+
+	return undefined;
+}
+
+function startReplay()
+{
+	if (!Engine.StartVisualReplay(g_GameData.gui.replayDirectory))
+	{
+		warn("Replay file not found!");
+		return;
+	}
+
+	Engine.SwitchGuiPage("page_loading.xml", {
+		"attribs": Engine.GetReplayAttributes(g_GameData.gui.replayDirectory),
+		"playerAssignments": {
+			"local": {
+				"name": singleplayerName(),
+				"player": -1
+			}
+		},
+		"savedGUIData": "",
+		"isReplay": true,
+		"replaySelectionData": g_GameData.gui.replaySelectionData
+	});
+}
+
+function initGUILabels()
+{
+	const assignedState = g_GameData.sim.playerStates[g_GameData.gui.assignedPlayer || -1];
+
+	Engine.GetGUIObjectByName("summaryText").caption =
+		g_GameData.gui.isInGame ?
+			translate("Current Scores") :
+			g_GameData.gui.isReplay ?
+				translate("Scores at the end of the game.") :
+				g_GameData.gui.disconnected ?
+					translate("You have been disconnected.") :
+					!assignedState ?
+						translate("You have left the game.") :
+						assignedState.state == "won" ?
+							translate("You have won the battle!") :
+							assignedState.state == "defeated" ?
+								translate("You have been defeated…") :
+								translate("You have abandoned the game.");
+
+	Engine.GetGUIObjectByName("timeElapsed").caption = sprintf(
+		translate("Game time elapsed: %(time)s"), {
+			"time": timeToString(g_GameData.sim.timeElapsed)
+		});
+
+	const mapType = g_Settings.MapTypes.find(type => type.Name == g_GameData.sim.mapSettings.mapType);
+	const mapSize = g_Settings.MapSizes.find(size => size.Tiles == g_GameData.sim.mapSettings.Size || 0);
+
+	Engine.GetGUIObjectByName("mapName").caption = sprintf(
+		translate("%(mapName)s - %(mapType)s"), {
+			"mapName": translate(g_GameData.sim.mapSettings.mapName),
+			"mapType": mapSize ? mapSize.Name : (mapType ? mapType.Title : "")
+		});
+}
+
+function initGUIButtons()
+{
+	const replayButton = Engine.GetGUIObjectByName("replayButton");
+	replayButton.hidden = g_GameData.gui.isInGame || !g_GameData.gui.replayDirectory;
+
+	const lobbyButton = Engine.GetGUIObjectByName("lobbyButton");
+	lobbyButton.tooltip = colorizeHotkey(translate("%(hotkey)s: Toggle the multiplayer lobby in a dialog window."), "lobby");
+	lobbyButton.hidden = g_GameData.gui.isInGame || !Engine.HasXmppClient();
+
+	// Right-align lobby button
+	const lobbyButtonSize = lobbyButton.size;
+	const lobbyButtonWidth = lobbyButtonSize.right - lobbyButtonSize.left;
+	lobbyButtonSize.right = (replayButton.hidden ? Engine.GetGUIObjectByName("continueButton").size.left : replayButton.size.left) - 10;
+	lobbyButtonSize.left = lobbyButtonSize.right - lobbyButtonWidth;
+	lobbyButton.size = lobbyButtonSize;
+
+	const allPanelsData = g_ScorePanelsData.concat(g_ChartPanelsData);
+	for (const tab in allPanelsData)
+		allPanelsData[tab].tooltip = sprintf(translate("Focus the %(name)s summary tab."), { "name": allPanelsData[tab].label });
+
+	placeTabButtons(
+		allPanelsData,
+		true,
+		g_TabButtonWidth,
+		g_TabButtonDist,
+		selectPanel,
+		selectPanelGUI);
+}
+
+function initTeamData()
+{
+	// Panels
+	g_PlayerCount = g_GameData.sim.playerStates.length - 1;
+
+	if (g_GameData.sim.mapSettings.LockTeams)
+	{
+		// Count teams
+		for (let player = 1; player <= g_PlayerCount; ++player)
+		{
+			const playerTeam = g_GameData.sim.playerStates[player].team;
+			if (!g_Teams[playerTeam])
+				g_Teams[playerTeam] = [];
+			g_Teams[playerTeam].push(player);
+		}
+
+		if (g_Teams.every(team => team && team.length < 2))
+			g_Teams = false;	// Each player has his own team. Displaying teams makes no sense.
+	}
+	else
+		g_Teams = false;
+
+	// Erase teams data if teams are not displayed
+	if (!g_Teams)
+		for (let p = 0; p < g_PlayerCount; ++p)
+			g_GameData.sim.playerStates[p+1].team = -1;
+}

--- a/gui/summary/summary.xml
+++ b/gui/summary/summary.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<objects>
+
+	<script directory="gui/common/"/>
+	<script directory="gui/summary/"/>
+
+	<object name="summaryHotkey" hotkey="summary"/>
+	<object name="cancelHotkey" hotkey="cancel"/>
+
+	<object type="image" sprite="ModernFade" name="fadeImage"/>
+
+	<object name="summaryWindow"
+		type="image"
+		style="ModernWindow"
+	>
+		<object name="summaryWindowTitle" type="text" style="ModernLabelText">
+			<translatableAttribute id="caption">Summary</translatableAttribute>
+		</object>
+
+		<object size="20 26 100%-20 92">
+
+			<object name="summaryText"
+				type="text"
+				size="0 16 33% 100%-16"
+				font="sans-bold-18"
+				textcolor="255 255 255"
+				text_align="left"
+				text_valign="center"
+			/>
+
+			<object name="timeElapsed"
+				type="text"
+				size="67% 16 100% 100%-16"
+				font="sans-bold-18"
+				textcolor="255 255 255"
+				text_align="right"
+				text_valign="center"
+			/>
+
+			<object name="mapName"
+				type="text"
+				size="34% 16 66% 100%-16"
+				font="sans-bold-18"
+				textcolor="255 255 255"
+				text_align="center"
+				text_valign="center"
+			/>
+
+		</object>
+
+		<object name="tabDividerLeft" type="image" sprite="ModernTabHorizontalSpacer" size="20 120 20 122"/>
+		<object name="tabDividerRight" type="image" sprite="ModernTabHorizontalSpacer" size="20 120 100%-20 122"/>
+
+		<object name="tabButtonsFrame" size="17 92 883 120">
+			<include file="gui/common/tab_buttons.xml"/>
+		</object>
+
+		<object name="generalPanel" type="image" sprite="ModernTabHorizontalFrame" size="20 120 100%-20 100%-54">
+			<object size="0 0 100% 100%-50">
+				<object name="playerNameHeading" type="text" style="ModernLeftTopLabelText">
+					<translatableAttribute id="caption">Player name</translatableAttribute>
+				</object>
+				<repeat var="x" count="20">
+					<object name="titleHeading[x]" type="text" style="ModernTopLabelText"/>
+				</repeat>
+				<repeat var="x" count="20">
+					<object name="Heading[x]" type="text" style="ModernLabelText"/>
+				</repeat>
+			</object>
+
+			<repeat count="4" var="i">
+				<object type="image" name="teamBoxt[i]" size="0 70 100% 100%-50" hidden="true">
+					<object type="text" name="teamNameHeadingt[i]" size="15 5 100% 100%" style="ModernLeftTopLabelText"/>
+					<object size="0 30 100% 100%">
+						<repeat count="8" var="n">
+							<object type="image" name="playerBoxt[i][n]" size="10 0 10 30" hidden="true">
+								<object name="playerOutcomet[i][n]" type="image" size="4 5 36 37"/>
+								<object name="playerNamet[i][n]" type="text" size="40 2 210 100%" style="ModernLeftLabelText"/>
+								<object name="civIcont[i][n]" type="image" size="210 5 242 37" />
+								<repeat var="x" count="20">
+									<object name="valueDataTeam[i][n][x]" type="text" style="ModernLabelText"/>
+								</repeat>
+							</object>
+						</repeat>
+					</object>
+					<object name="teamHeadingt[i]" type="text" style="ModernLeftLabelText"/>
+					<repeat var="x" count="20">
+						<object name="valueDataTeam[i][x]" type="text" style="ModernLabelText"/>
+					</repeat>
+				</object>
+			</repeat>
+
+			<object type="image" name="noTeamsBox" size="0 70 100% 100%-50" hidden="true">
+				<repeat count="8">
+					<object type="image" name="playerBox[n]" size="10 0 10 30" hidden="true">
+						<object name="playerOutcome[n]" type="image" size="4 5 36 37"/>
+						<object name="playerName[n]" type="text" size="40 2 210 100%" style="ModernLeftLabelText"/>
+						<object name="civIcon[n]" type="image" size="210 5 242 37"/>
+						<repeat var="x" count="20">
+							<object name="valueData[n][x]" type="text" style="ModernLabelText"/>
+						</repeat>
+					</object>
+				</repeat>
+			</object>
+		</object>
+
+		<object name="chartsPanel" type="image" sprite="ModernTabHorizontalFrame" size="20 120 100%-20 100%-54">
+			<repeat count="2" var="k">
+				<object name="chart[k]Part" size="15 0 50%-10 100%-35">
+					<object type="text" style="ModernLeftLabelText" size="1 6 145 26">
+						<translatableAttribute id="caption" context="summary chart">Category:</translatableAttribute>
+					</object>
+					<object name="chart[k]CategorySelection"
+						type="dropdown"
+						style="ModernDropDown"
+						size="5 28 145 56">
+						<translatableAttribute id="tooltip" context="summary chart">Category</translatableAttribute>
+					</object>
+
+					<object type="text" style="ModernLeftLabelText" size="151 6 295 26">
+						<translatableAttribute id="caption" context="summary chart">Value:</translatableAttribute>
+					</object>
+					<object name="chart[k]ValueSelection"
+						type="dropdown"
+						style="ModernDropDown"
+						size="155 28 295 56">
+						<translatableAttribute id="tooltip" context="summary chart">Value</translatableAttribute>
+					</object>
+
+					<object name="chart[k]TypeLabel" type="text" style="ModernLeftLabelText" size="301 6 445 26">
+						<translatableAttribute id="caption" context="summary chart">Type:</translatableAttribute>
+					</object>
+					<object name="chart[k]TypeSelection"
+						type="dropdown"
+						style="ModernDropDown"
+						hidden="true"
+						size="305 28 445 56">
+						<translatableAttribute id="tooltip" context="summary chart">Type</translatableAttribute>
+					</object>
+
+					<object type="image" sprite="color: 255 255 255 20" size="0 80 100% 100%"/>
+					<object name="chart[k]" type="chart" style="ModernChart" format_x="DURATION_SHORT" format_y="INTEGER" size="5 85 100%-5 100%-25"/>
+					<object name="chart[k]XAxisLabel" type="text" style="ModernLabelText" size="5 100%-25 100%-5 100%-5"/>
+				</object>
+			</repeat>
+
+			<object name="chartLegend" type="text" style="ModernLabelText" size="15 100%-35 100%-15 100%-5"/>
+
+			<object name="toggleTeam" size="4 100%+6 50% 100%+34">
+				<object name="toggleTeamBox" size="0 3 22 100%-3" type="checkbox" style="ModernTickBox">
+					<action on="Press">
+						updateChartColorAndLegend();
+						updateCategoryDropdown(0);
+						updateCategoryDropdown(1);
+					</action>
+				</object>
+				<object name="toggleTeamText" size="20 0 100% 100%" type="text" style="ModernLeftLabelText">
+					<translatableAttribute id="caption">Group by team</translatableAttribute>
+				</object>
+			</object>
+		</object>
+
+		<!-- View Lobby Button -->
+		<object name="lobbyButton"
+			type="button"
+			sprite="iconBubbleGold"
+			sprite_over="iconBubbleWhite"
+			size="100%-436 100%-45 100%-420 100%-29"
+			z="50"
+			hotkey="lobby"
+		>
+			<action on="Press">
+				if (Engine.HasXmppClient())
+					Engine.OpenChildPage("page_lobby.xml", { "dialog": true });
+			</action>
+		</object>
+
+		<object type="button" name="replayButton" style="ModernButtonRed" size="100%-410 100%-48 100%-210 100%-20" z="50">
+			<translatableAttribute id="caption">Watch Replay</translatableAttribute>
+			<action on="Press">startReplay();</action>
+		</object>
+
+		<object type="button" name="continueButton" style="ModernButtonRed" size="100%-200 100%-48 100%-20 100%-20" z="50">
+			<translatableAttribute id="caption">Continue</translatableAttribute>
+		</object>
+	</object>
+</objects>

--- a/simulation/templates/template_player.xml
+++ b/simulation/templates/template_player.xml
@@ -300,6 +300,7 @@
       Cavalry
       Champion
       Domestic
+      FemaleCitizen
       Villager
       Hero
       Infantry
@@ -307,6 +308,7 @@
       Siege
       Trader
       Unit
+      Worker
       Slave
     </UnitClasses>
     <StructureClasses datatype="tokens">


### PR DESCRIPTION
Hello im trompetin17 from 0AD, this PR is to help to enable the game without issues and open the summary screen.

Im adding summary.xml and summary.js because there is a limitation about only 9 "columns" and resources have more than 9, so while i make the pr and fix prior next version, this is the workaround from now.

# Evidences

## Game opened

![image](https://github.com/user-attachments/assets/30b59b50-1b63-4d16-9622-a1538cf85324)

## A Game

![image](https://github.com/user-attachments/assets/504a8f60-7f7e-4000-bf24-8ffe8e36f64a)

## Summary

### Normal

![image](https://github.com/user-attachments/assets/f70d5d05-8135-49bb-8535-74032bc9a098)

### Resources

![image](https://github.com/user-attachments/assets/de15b715-6b20-47e0-a8bb-676c6a3d071e)

